### PR TITLE
Add UDEV_TOUCH_SUPPORT flag to enable RetroArch touch input

### DIFF
--- a/scripts/retroarch.sh
+++ b/scripts/retroarch.sh
@@ -75,7 +75,7 @@ bitness="$(getconf LONG_BIT)"
 	    --enable-udev \
 	    --enable-wifi
       else
-	    CFLAGS="-Ofastast -march=armv8-a -mtune=cortex-a55 -mfpu=neon-fp-armv8 -mfloat-abi=hard -fomit-frame-pointer -DNDEBUG -DUDEV_TOUCH_SUPPORT" \
+	    CFLAGS="-Ofast -march=armv8-a -mtune=cortex-a55 -mfpu=neon-fp-armv8 -mfloat-abi=hard -fomit-frame-pointer -DNDEBUG -DUDEV_TOUCH_SUPPORT" \
 	    ./configure \
 	    --disable-caca \
 	    --disable-mali_fbdev \

--- a/scripts/retroarch.sh
+++ b/scripts/retroarch.sh
@@ -49,7 +49,7 @@ bitness="$(getconf LONG_BIT)"
 	  done
 	 fi
 	  if [[ "$bitness" == "64" ]]; then
-	    CFLAGS="-Ofast -march=armv8-a -mtune=cortex-a55 -fomit-frame-pointer -DNDEBUG" \
+	    CFLAGS="-Ofast -march=armv8-a -mtune=cortex-a55 -fomit-frame-pointer -DNDEBUG -DUDEV_TOUCH_SUPPORT" \
 	    ./configure \
 	    --disable-caca \
 	    --disable-mali_fbdev \
@@ -75,7 +75,7 @@ bitness="$(getconf LONG_BIT)"
 	    --enable-udev \
 	    --enable-wifi
       else
-	    CFLAGS="-Ofast -march=armv8-a -mtune=cortex-a55 -mfpu=neon-fp-armv8 -mfloat-abi=hard -fomit-frame-pointer -DNDEBUG" \ 
+	    CFLAGS="-Ofastast -march=armv8-a -mtune=cortex-a55 -mfpu=neon-fp-armv8 -mfloat-abi=hard -fomit-frame-pointer -DNDEBUG -DUDEV_TOUCH_SUPPORT" \
 	    ./configure \
 	    --disable-caca \
 	    --disable-mali_fbdev \


### PR DESCRIPTION
Hi, 

As mentioned in https://github.com/christianhaitian/arkos/issues/734 , the RetroArch is being compiled without 
touch support. Adding the `UDEV_TOUCH_SUPPORT` flag fixes this. The resulting `retroarch` 
and `retroarch32` now provide the experimental touch support.