### PR TITLE
Update msgbox

### DIFF
--- a/shell-scripts/msgbox
+++ b/shell-scripts/msgbox
@@ -51,7 +51,13 @@ fi
 export TERM=linux
 export XDG_RUNTIME_DIR=/run/user/$UID/
 
-dialog --clear --msgbox "$1" $height $width 2>&1 > /dev/tty1
+# If a second argument (a dialog title) is given, we'll add it as output
+if [ -n "$2" ]; then
+  dialog --clear --title "$2" --msgbox "$1" $height $width 2>&1 > /dev/tty1
+else
+  # If no dialog title is given we'll just use the orignial line
+  dialog --clear --msgbox "$1" $height $width 2>&1 > /dev/tty1
+fi 
 
 if [[ ! -z "$set_gptokeyb" ]]; then
   pgrep -f gptokeyb | sudo xargs kill -9


### PR DESCRIPTION
A simple update so message boxes can now also use titles for a bit more cleaner and organized look when desired. For example if creating a multi menu/message script.

This update if fully backwards compatible with existing scripts because if the second parameter isn't given, then the old original code will be executed of displaying a message box (dialog) without title.