### PR TITLE
Update USB Drive Mount.sh

### DIFF
--- a/shell-scripts/USB Drive Mount.sh
+++ b/shell-scripts/USB Drive Mount.sh
@@ -8,7 +8,12 @@ if [ "$filesystem" = "ntfs" ]; then
 	filesystem="ntfs-3g"
 fi
 
-sudo mount -t $filesystem /dev/sda1 /mnt/usbdrive -o uid=1002
+altCharSet=""
+if [[ "$filesystem" =~ ^(vfat|fat16|fat32|ntfs|ntfs_3g)$ ]]; then
+	altCharSet=",iocharset=iso8859-1"
+fi
+
+sudo mount -t $filesystem /dev/sda1 /mnt/usbdrive -o uid=1002,gid=1002$altCharSet
 status=$?
 
 if test $status -eq 0


### PR DESCRIPTION
Updated the script to detect if it's vfat,fat16,fat32,ntfs/ntfs_3g so that it uses iocharset=iso8859-1 to prevent UTF-8 errors (and/or case sensitive issues with files names)

Did the pull-request again in the same fork from which you already accepted the msgbox update. For some reason it decided that it created a secondary fork for this update initially which I didn't noticed earlier. My apologies :)
